### PR TITLE
movies.py:

### DIFF
--- a/cinemacity_crawlers/cinemacity_crawlers/pipelines.py
+++ b/cinemacity_crawlers/cinemacity_crawlers/pipelines.py
@@ -15,7 +15,7 @@ cinemas_to_dump = {}
 
 class CinemacityCrawlersPipeline:
     def __init__(self):
-        self.conn = sqlite3.connect('../vbot.db')
+        self.conn = sqlite3.connect('../vbot.db')  # this path is probably invalid in UNIX
         self.cursor = self.conn.cursor()
         self.create_tables()
 
@@ -32,16 +32,27 @@ class CinemacityCrawlersPipeline:
         self.conn.close()
 
     def create_tables(self):
+        self.cursor.execute("""CREATE TABLE IF NOT EXISTS cinemas (
+                                cinema_id TEXT PRIMARY KEY,
+                                cinema_name TEXT NOT NULL,
+                                cinema_image_url TEXT NOT NULL
+                                )""")
+        self.cursor.execute("""CREATE TABLE IF NOT EXISTS movies(
+                                movie_id TEXT PRIMARY KEY,
+                                poster_link TEXT NOT NULL,
+                                movie_link TEXT NOT NULL,
+                                trailer_link TEXT
+                                )""")
         self.cursor.execute("""CREATE TABLE IF NOT EXISTS today (
-                                        cinema_id NUMERIC PRIMARY KEY,
-                                        json TEXT,
-                                        FOREIGN KEY(cinema_id) REFERENCES cinemas(cinema_id) 
-                                        )""")
+                                cinema_id TEXT PRIMARY KEY,
+                                json TEXT,
+                                FOREIGN KEY(cinema_id) REFERENCES cinemas(cinema_id)
+                                )""")
         self.cursor.execute("""CREATE TABLE IF NOT EXISTS yesterday (
-                                        cinema_id NUMERIC PRIMARY KEY,
-                                        json TEXT,
-                                        FOREIGN KEY(cinema_id) REFERENCES cinemas(cinema_id) 
-                                        )""")
+                                cinema_id TEXT PRIMARY KEY,
+                                json TEXT,
+                                FOREIGN KEY(cinema_id) REFERENCES cinemas(cinema_id)
+                                )""")
 
     def fetch_cinemas(self):
         res = self.cursor.execute("SELECT cinema_id FROM cinemas").fetchall()

--- a/cinemacity_crawlers/cinemacity_crawlers/spiders/movies.py
+++ b/cinemacity_crawlers/cinemacity_crawlers/spiders/movies.py
@@ -17,12 +17,10 @@ output_dates = {}
 cinemas = {}
 
 
-# self.cursor.execute("INSERT OR IGNORE INTO cinemas(cinema_id) VALUES (:cinema_id)", {'cinema_id': cinema_id})
-
 class MoviesSpider(scrapy.Spider):
     name = 'movies'
     start_urls = ['https://www.cinemacity.bg/']
-    conn = sqlite3.connect('../vbot.db')
+    conn = sqlite3.connect('../vbot.db')  # this path is probably invalid in UNIX
     cursor = conn.cursor()
 
     def parse(self, response):
@@ -38,10 +36,6 @@ class MoviesSpider(scrapy.Spider):
             cinema_id = cinema['id']
             cinema_name = cinema['displayName']
             cinema_image_url = cinema['imageUrl']
-            self.cursor.execute("""CREATE TABLE IF NOT EXISTS cinemas (
-                                    cinema_id NUMERIC PRIMARY KEY,
-                                    cinema_name TEXT NOT NULL,
-                                    cinema_image_url TEXT NOT NULL)""")
             self.cursor.execute("INSERT OR IGNORE INTO cinemas(cinema_id, cinema_name, cinema_image_url) "
                                 "VALUES (:cinema_id, :cinema_name, :cinema_image_url)",
                                 {'cinema_id': cinema_id,
@@ -100,12 +94,6 @@ class MoviesSpider(scrapy.Spider):
                     'trailer_link': trailer_link,
                 }
 
-            self.cursor.execute("""CREATE TABLE IF NOT EXISTS movies(
-            movie_id TEXT PRIMARY KEY,
-            poster_link TEXT NOT NULL,
-            movie_link TEXT NOT NULL,
-            trailer_link TEXT           
-            )""")
             self.cursor.execute("INSERT OR IGNORE INTO movies(movie_id, poster_link, movie_link,trailer_link) "
                                 "VALUES (:movie_id, :poster_link, :movie_link, :trailer_link);", {
                                     'movie_id': movie_id,


### PR DESCRIPTION
    - removed create table cinemas query from movies.py
    - removed create table movies query from movies.py
pipelines.py:
    - create table cinemas query is now in pipelines.py as CinemacityCrawlersPipeline's __init__ is ran before the movies.py and foreign key was not working when the table creation was in movies.py
    - create table movies query is now in pipelines.py for consistency